### PR TITLE
remove circular reference from meta

### DIFF
--- a/lib/winston-logstash-udp.js
+++ b/lib/winston-logstash-udp.js
@@ -15,7 +15,8 @@ var dgram = require('dgram'),
     util = require('util'),
     os = require('os'),
     winston = require('winston'),
-    common = require('winston/lib/winston/common');
+    common = require('winston/lib/winston/common'),
+    cycle = require('cycle');
 
 var LogstashUDP = exports.LogstashUDP = function(options) {
     winston.Transport.call(this, options);
@@ -48,7 +49,7 @@ LogstashUDP.prototype.connect = function() {
 
 LogstashUDP.prototype.log = function(level, msg, meta, callback) {
     var self = this,
-        meta = winston.clone(meta || {}),
+        meta = winston.clone(cycle.decycle(meta) || {}),
         logEntry;
 
     callback = (callback || function() {});

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "url": "https://github.com/sazze/winston-logstash-udp.git"
     },
     "dependencies": {
+        "cycle": "^1.0.3",
         "winston": ">=0.7.2"
     },
     "devDependencies": {


### PR DESCRIPTION
If meta has circular reference, clone() method occurs infinite recursive call.
As a result, you will see "RangeError: Maximum call stack size exceeded." message on you console.
So, I remove circular reference before use clone() method.
