### PR TITLE
Add an option for appending trailing line-feeds to every log

### DIFF
--- a/lib/winston-logstash-udp.js
+++ b/lib/winston-logstash-udp.js
@@ -30,6 +30,7 @@ var LogstashUDP = exports.LogstashUDP = function(options) {
     this.application = options.appName || process.title;
     this.pid = options.pid || process.pid;
     this.trailingLineFeed = options.trailingLineFeed === true;
+    this.trailingLineFeedChar = options.trailingLineFeedChar || os.EOL;
 
     this.client = null;
 
@@ -82,7 +83,7 @@ LogstashUDP.prototype.sendLog = function(message, callback) {
     var self = this;
 
     if (this.trailingLineFeed === true) {
-        message = message.replace(/\n$/, '') + "\n";
+        message = message.replace(/\n$/, '') + this.trailingLineFeedChar;
     }
 
     var buf = new Buffer(message);

--- a/lib/winston-logstash-udp.js
+++ b/lib/winston-logstash-udp.js
@@ -83,7 +83,7 @@ LogstashUDP.prototype.sendLog = function(message, callback) {
     var self = this;
 
     if (this.trailingLineFeed === true) {
-        message = message.replace(/\n$/, '') + this.trailingLineFeedChar;
+        message = message.replace(/\s+$/, '') + this.trailingLineFeedChar;
     }
 
     var buf = new Buffer(message);

--- a/lib/winston-logstash-udp.js
+++ b/lib/winston-logstash-udp.js
@@ -29,6 +29,7 @@ var LogstashUDP = exports.LogstashUDP = function(options) {
     this.port = options.port || 9999;
     this.application = options.appName || process.title;
     this.pid = options.pid || process.pid;
+    this.trailingLineFeed = options.trailingLineFeed === true;
 
     this.client = null;
 
@@ -79,6 +80,11 @@ LogstashUDP.prototype.log = function(level, msg, meta, callback) {
 
 LogstashUDP.prototype.sendLog = function(message, callback) {
     var self = this;
+
+    if (this.trailingLineFeed === true) {
+        message = message.replace(/\n$/, '') + "\n";
+    }
+
     var buf = new Buffer(message);
 
     callback = (callback || function() {});

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "winston": ">=0.7.2",
         "mocha": ">=1.8.2",
         "chai": ">=1.5.0",
-        "timekeeper": ">=0.0.3"
+        "timekeeper": ">=0.0.3",
+        "sinon-chai": "~2.8.0"
     },
     "keywords": [
         "logging",

--- a/test/winston-logstash-udp_test.js
+++ b/test/winston-logstash-udp_test.js
@@ -5,6 +5,7 @@ var chai = require('chai'),
     dgram = require('dgram'),
     winston = require('winston'),
     timekeeper = require('timekeeper'),
+    os = require('os'),
     freezed_time = new Date(1330688329321);
 
 chai.Assertion.includeStack = true;
@@ -80,20 +81,39 @@ describe('winston-logstash-udp transport', function () {
             logger.log('info', 'hello world', {stream: 'sample'});
         });
 
-        it('add trailing line-feed if the option is on', function (done) {
-            var logger = createLogger(
-                port,
-                {
-                    trailingLineFeed: true
-                }
-            );
+        describe('with the option \'trailing line-feed\' on', function () {
+            it('add operating system\'s default EndOfLine character as trailing line-feed, by default', function (done) {
+                var logger = createLogger(
+                    port,
+                    {
+                        trailingLineFeed: true
+                    }
+                );
 
-            test_server = createTestServer(port, function (data) {
-                expect(data.toString().slice(-1)).to.be.eql("\n");
-                done();
+                test_server = createTestServer(port, function (data) {
+                    expect(data.toString().slice(-1)).to.be.eql(os.EOL);
+                    done();
+                });
+
+                logger.log('info', 'hello world', {stream: 'sample'});
             });
 
-            logger.log('info', 'hello world', {stream: 'sample'});
+            it('add a specific character as trailing line-feed, if set in options', function (done) {
+                var logger = createLogger(
+                    port,
+                    {
+                        trailingLineFeed: true,
+                        trailingLineFeedChar: "\r\n"
+                    }
+                );
+
+                test_server = createTestServer(port, function (data) {
+                    expect(data.toString().slice(-2)).to.be.eql("\r\n");
+                    done();
+                });
+
+                logger.log('info', 'hello world', {stream: 'sample'});
+            });
         });
 
         // Teardown

--- a/test/winston-logstash-udp_test.js
+++ b/test/winston-logstash-udp_test.js
@@ -103,12 +103,12 @@ describe('winston-logstash-udp transport', function () {
                     port,
                     {
                         trailingLineFeed: true,
-                        trailingLineFeedChar: "\r\n"
+                        trailingLineFeedChar: os.EOL + "\n"
                     }
                 );
 
                 test_server = createTestServer(port, function (data) {
-                    expect(data.toString().slice(-2)).to.be.eql("\r\n");
+                    expect(data.toString().slice(-(os.EOL.length + 1))).to.be.eql(os.EOL + "\n");
                     done();
                 });
 

--- a/test/winston-logstash-udp_test.js
+++ b/test/winston-logstash-udp_test.js
@@ -91,7 +91,7 @@ describe('winston-logstash-udp transport', function () {
                 );
 
                 test_server = createTestServer(port, function (data) {
-                    expect(data.toString().slice(-1)).to.be.eql(os.EOL);
+                    expect(data.toString().slice(-os.EOL.length)).to.be.eql(os.EOL);
                     done();
                 });
 


### PR DESCRIPTION
Kibana, as configured in the company I am working for, cannot parse logs if they don't end with a line feed.

This PR adds an option "endWithNewLine" which, when true, automatically ensures the log sent to Logstash ends with a line feed.
This option does not break backward compatibility as it defaults to false.
