### PR TITLE
Fix node packages installation error caused by assertion-error depend…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - "0.10"
   - "0.8"
+before_install:
+  - npm install -g npm@~1.4.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ node_js:
   - "0.10"
   - "0.8"
 before_install:
-  - npm install -g npm@~1.4.6
+  - '[ "${TRAVIS_NODE_VERSION}" != "0.8" ] || npm install -g npm@~1.4.6'

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Troubleshooting
   npm install -g npm@~1.4.6
   ```
 
+  Another way around is to simply avoid installing the development dependencies:
+
+  ```
+  npm install --production
+  ```
+
 ====================
 
 #### Author: [Craig Thayer](https://github.com/sazze)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ Run Tests
   npm test
 ```
 
+Troubleshooting
+====================
+
+* **I get an error when installing node packages *"ERR! Error: No compatible version found: assertion-error@'^1.0.1'"***
+
+  If you are running a version of NodeJS less than or equal to 0.8, upgrading NPM to a version greater than or equal to 1.4.6 should solve this issue.
+
+  ```
+  npm install -g npm@~1.4.6
+  ```
+
 ====================
 
 #### Author: [Craig Thayer](https://github.com/sazze)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "test": "mocha test/*_test.js"
     },
     "engines": {
-        "node": ">=0.8.x"
+        "node": ">=0.8.x",
+        "npm" : ">=1.4.6"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
### The issue

I noticed that a Travis build failed when running NodeJS 0.8, because it could not install all dependencies : https://travis-ci.org/sazze/winston-logstash-udp/builds/69252223

After a little investigation, it appears Chai is the root of the issue. Indeed, since its release 3.0.0, Chai changed its dependency to 'assertion-error' from '1.0.1' to '^1.0.1', which fails to resolve with NPM versions < 1.4.6, as these versions does not support the caret syntax yet.

Actually, I am not sure about that 1.4.6 version, I completely trusted this blog post: http://tech.vg.no/2014/05/30/npm-travis-node-and-the-caret-operator/

But anyway, it turns out NodeJS <= 0.8 comes by default with a version of NPM that does not support the caret operator, and this is why the Travis build fails.
### The solutions

I see three possible solutions:
- stop officially supporting nodeJS <= 0.8
- stop relying on the latest version of Chai and explicitly ask for a version <3.0.0
- continue to support nodeJS <= 0.8 and use the latest version of Chai, and simply warn the users about the dependency on NPM >= 1.4.6

Obviously, I would say the best option out of the three is the last one, which is why I suggest the following changes:
- for the Travis build: fix it by manually installing the appropriate version of NPM
- for the people out there who use winston-logstash-udp in their project: specify the dependency to NPM >= 1.4.6 in the package.json, and add a troubleshooting section in the README
