### PR TITLE
handle error oject specifically

### DIFF
--- a/lib/winston-logstash-udp.js
+++ b/lib/winston-logstash-udp.js
@@ -51,8 +51,16 @@ LogstashUDP.prototype.connect = function() {
 
 LogstashUDP.prototype.log = function(level, msg, meta, callback) {
     var self = this,
-        meta = winston.clone(cycle.decycle(meta) || {}),
         logEntry;
+
+    if (meta && meta instanceof Error && meta.stack) {
+        msg = meta.message;
+        meta = {
+          stack: meta.stack
+        };
+    } else {
+        meta = winston.clone(cycle.decycle(meta) || {});
+    }
 
     callback = (callback || function() {});
 


### PR DESCRIPTION
fix when `winston.log(new Error('cool'))`, winston-logstash-udp send nothing to logstash
