### PR TITLE
use own cycle dependency

### DIFF
--- a/lib/winston-logstash-udp.js
+++ b/lib/winston-logstash-udp.js
@@ -16,7 +16,7 @@ var dgram = require('dgram'),
     os = require('os'),
     winston = require('winston'),
     common = require('winston/lib/winston/common'),
-    cycle = require('winston/node_modules/cycle');
+    cycle = require('cycle');
 
 var LogstashUDP = exports.LogstashUDP = function(options) {
     winston.Transport.call(this, options);

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "url": "https://github.com/sazze/winston-logstash-udp.git"
     },
     "dependencies": {
+        "cycle": "^1.0.3",
         "winston": ">=0.7.2"
     },
     "devDependencies": {


### PR DESCRIPTION
Because you should never use one that is provided by another module.
It also breaks the module if you use dedupe or npm 3.
