### PR TITLE
skipping exceptions throws by dgram on dns lookup failure

### DIFF
--- a/lib/winston-logstash-udp.js
+++ b/lib/winston-logstash-udp.js
@@ -46,7 +46,14 @@ util.inherits(LogstashUDP, winston.Transport);
 winston.transports.LogstashUDP = LogstashUDP;
 
 LogstashUDP.prototype.connect = function() {
+    var self = this;
     this.client = dgram.createSocket('udp4');
+
+    // Attach an error listener on the socket
+    // It can also avoid top level exceptions like UDP DNS errors throwned by the socket
+    this.client.on('error', function(err) {
+        self.emit('error', err);
+    });
 };
 
 LogstashUDP.prototype.log = function(level, msg, meta, callback) {

--- a/test/winston-logstash-udp_test.js
+++ b/test/winston-logstash-udp_test.js
@@ -137,4 +137,21 @@ describe('winston-logstash-udp transport', function () {
 
     });
 
+    describe('without logstash server', function () {
+
+        // UDP DNS errors only happen on node's version <= 0.12
+        if(Number(process.version.match(/^v(\d+\.\d+)/)[1]) <= 0.12) {
+
+            it('emit an error message if UDP DNS errors occur on the socket (these errors only happen on node\'s version <= 0.12)', function (done) {
+                var logger = createLogger(port, {host:'unresolvedhost'});
+                   
+                logger.transports.logstashUdp.on('error', function (err) {
+                    expect(err).to.be.an.instanceof(Error);
+                    done();
+                });
+
+                logger.log('info', 'hello world', {stream: 'sample'});
+            });
+        }
+    });
 });


### PR DESCRIPTION
If you create a udp4 socket and send some data over it to an hostname that cannot be resolved, unfortunately, dgram from node (<=0.12.x) will throw a top-level exception which kills the entire app.

This is a workaround to avoid this exception.
This issue is closed on recent node version (see https://github.com/nodejs/node-v0.x-archive/issues/4846 for more information) but not on branch 0.12.x and earlier
